### PR TITLE
print authorized_keys file after ldap keys

### DIFF
--- a/auth_key_git/__init__.py
+++ b/auth_key_git/__init__.py
@@ -7,7 +7,7 @@ import sys
 from os.path import expanduser
 
 
-def load_config(filename):
+def load_config():
     defaults = {
         'shell': '/usr/lib/gitolite/gitolite-shell',
         'options': 'no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty',
@@ -29,7 +29,7 @@ def main():
         exit(0)
     username = sys.argv[1]
 
-    config = load_config('/etc/auth-key-git.conf')
+    config = load_config()
     if username != config.get('git', 'user'):
         exit(0)
 

--- a/auth_key_git/__init__.py
+++ b/auth_key_git/__init__.py
@@ -33,6 +33,12 @@ def main():
     if username != config.get('git', 'user'):
         exit(0)
 
+    try:
+        with open(expanduser('~%s/.ssh/authorized_keys' % username)) as f:
+            print(f.read())
+    except:
+        pass
+
     def command(user):
         return "command=\"%s %s\"" % (config.get('git', 'shell'), user)
 


### PR DESCRIPTION
It is done for "special" users like gitolite admins needing a special ssh command.

PS: small cleanup of the `load_config` function.